### PR TITLE
Bump 1Password to 8.10.78

### DIFF
--- a/docker/config/version.json
+++ b/docker/config/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "8.10.76",
-  "release_date": "May 13 2025"
+  "version": "8.10.78",
+  "release_date": "May 27 2025"
 }


### PR DESCRIPTION
This PR updates 1Password to **8.10.78**.
CI will verify the Docker build before merge.